### PR TITLE
feat: add Flask app skeleton with home/about and healthz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ charts/**/charts/
 
 # Jenkins & CI
 **/workspace/
+
+notesx.txt

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ A production-style portfolio site implemented as a **DevOps practice project**:
 - Helm chart deploys to **dev** namespace with probes
 - Tag `v0.1.0` from `main` → promote to **prod**
 
-## Repo layout (planned)
+# Repo layout (planned)

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,32 @@
+# app/app.py
+from flask import Flask, render_template, jsonify
+from prometheus_flask_exporter import PrometheusMetrics
+
+# Create a single metrics object for the whole process
+metrics = PrometheusMetrics.for_app_factory()
+# Register static info ONCE against that metrics object
+metrics.info('app_info', 'Portfolio service info', version='0.1.0')
+
+def create_app():
+    app = Flask(__name__)
+    # Initialize metrics for this app instance (no duplicate registration)
+    metrics.init_app(app)
+
+    @app.route('/')
+    def home():
+        return render_template('home.html')
+
+    @app.route('/about')
+    def about():
+        return render_template('about.html')
+
+    @app.route('/healthz')
+    def healthz():
+        return jsonify(status='ok'), 200
+
+    return app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="text-3xl font-bold">About Me</h1>
+<p class="mt-2">I'm Delvyn Jones, a DevOps/Cloud Engineer passionate about automation, CI/CD, Kubernetes, and observability.</p>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title or "Delvyn Jones • DevOps Portfolio" }}</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-900 text-white">
+  <header class="p-4 bg-gray-800">
+    <nav class="flex gap-4">
+      <a href="/" class="hover:underline">Home</a>
+      <a href="/about" class="hover:underline">About</a>
+    </nav>
+  </header>
+
+  <main class="p-6">
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer class="p-4 bg-gray-800 text-sm text-gray-400 text-center">
+    © 2025 Delvyn Jones
+  </footer>
+</body>
+</html>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="text-3xl font-bold">Welcome to my Portfolio</h1>
+<p class="mt-2">This site is built as a DevOps learning project — containerized, CI/CD-enabled, and monitored.</p>
+{% endblock %}

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,9 @@
+this is the instructuions and manual for this project that I am doing
+
+for step 0, I did the skeleton of the project in my local machine and then coded 3 files
+README.md, .gitignore, and PULL_REQUEST_TEMPLATE.md
+
+Used git commands init,add and did my first commmit.
+
+
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+# pytest.ini
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask==3.0.3
+pytest==8.3.2
+prometheus-flask-exporter==0.23.0
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,14 @@
+import pytest
+from app.app import create_app
+
+@pytest.fixture()
+def client():
+    app = create_app()
+    app.config.update({"TESTING": True})
+    with app.test_client() as client:
+        yield client
+
+def test_routes(client):
+    for path in ["/", "/about", "/healthz"]:
+        res = client.get(path)
+        assert res.status_code == 200


### PR DESCRIPTION
### 3) `.github/PULL_REQUEST_TEMPLATE.md`
```markdown
## Summary
<!-- What change is this PR introducing? One or two sentences. -->
This PR is introducing the locally tested 2 features of this app which are home page and about page of the portfolio.
## Scope / Pages
- [ ] Home (`/`)
- [ ] About (`/about`)
- [ ] Projects (`/projects`)
- [ ] Skills (`/skills`)
- [ ] Contact (`/contact`)
- [ ] Infra / CI / Ops

## How to Test
1. Run `pytest -q`
2. Start app and verify routes:
   - `curl -f http://localhost:8080/healthz`
   - Open `http://localhost:8080/`
3. (If container) `docker build .` then `docker run -p 8080:8080 ...`

## Risk & Rollback
- **Risk:** <!-- low/medium/high and why -->
- **Rollback:** Re-deploy previous image tag via Helm: